### PR TITLE
fix: correct prompt style error in TerminalUI

### DIFF
--- a/src/ui/terminal.py
+++ b/src/ui/terminal.py
@@ -37,10 +37,8 @@ class TerminalUI:
     
     def display_prompt(self):
         """Display the command prompt."""
-        return Prompt.ask(
-            "\nh4ck3r@voidnet:~$",
-            style=self.prompt_style
-        )
+        self.console.print("\nh4ck3r@voidnet:~$", style=self.prompt_style, end="")
+        return input()
     
     def display_error(self, message: str):
         """Display an error message."""


### PR DESCRIPTION
## Changes\n- Removed `style` parameter from `Prompt.ask()`\n- Used `rich.print()` with style before the prompt\n- Used standard `input()` for command input\n\n## Verification\n- [x] The prompt displays correctly with the cyberpunk style\n- [x] No TypeError is raised\n- [x] The command input works as expected